### PR TITLE
Deploy new clamav version to TTA Hub prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: "3.5"
 
 services:
   clamav-server:
-    image: ajilaag/clamav-rest:20201028
+    image: ajilaag/clamav-rest:20211026
     ports:
       - "9443:9443"

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,6 @@ applications:
   memory: 2G
   disk_quota: 2G
   docker:
-    image: ajilaag/clamav-rest:20201028
+    image: ajilaag/clamav-rest:20211026
   routes:
   - route: clamapi-((project)).apps.internal


### PR DESCRIPTION
Updates docker tag to https://hub.docker.com/layers/ajilaag/clamav-rest/20211026/images/sha256-163084395968e2f9be7c2211614585847cfbcf0a73b8d2d6a425666fdde26cfc?context=explore

Only merge after #6 has been merged and tested to verify things are working properly.