### PR TITLE
Update docker image used for clam-av rest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   clamav-server:
-    image: ajilaag/clamav-rest:20211026
+    image: ajilaag/clamav-rest:20221117
     ports:
       - "9443:9443"
     environment:


### PR DESCRIPTION
This is an attempt to address issues with jobs failing one or more times in our cloud.gov environment.
If this PR is approved, I can deploy to our "deploy-dev" branch for verification in lower environments.

### How to test
Locally - pin your clamav-rest image to 20221117 and verify that upload/scan jobs are completing