### PR TITLE
Deploy newest virus scanner image to dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   clamav-server:
-    image: ajilaag/clamav-rest:20211026
+    image: ajilaag/clamav-rest:20221117
     ports:
       - "9443:9443"
     environment:


### PR DESCRIPTION
Updates docker tag [to latest specified version](https://hub.docker.com/layers/ajilaag/clamav-rest/20221117/images/sha256-d6a45f107f32633f189d1c4d3c26dacc61d838c90066a13299471fef18c2c0d2?context=explore)

Verified that this version of the virus scanner works in local environment, this PR will deploy the updated scanner version to sandbox, development, and staging environment for testing before opening a PR to deploy to prod.
