### PR TITLE
Update docker image used for clam-av rest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   clamav-server:
-    image: ajilaag/clamav-rest:20211026
+    image: ajilaag/clamav-rest:20221117
     ports:
       - "9443:9443"
     environment:


### PR DESCRIPTION
Updates docker tag [to latest specified version](https://hub.docker.com/layers/ajilaag/clamav-rest/20221117/images/sha256-d6a45f107f32633f189d1c4d3c26dacc61d838c90066a13299471fef18c2c0d2?context=explore)

Verified that the virus scanner works on the lower environments, although noting here that additional configuration was necessary (creating a network policy) so that will have to be checked and possibly done to prod immediately after this PR is merged

## How to test
Upload a file to staging via the app. Check the logs and verify the successful completion of job.