### PR TITLE
[TTAHUB-3124] Increase CLAMAV memory

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: clamav-api-((project))
   instances: 1
-  memory: 2G
+  memory: 4G
   disk_quota: 2G
   docker:
     image: ajilaag/clamav-rest:20211026


### PR DESCRIPTION
Increase memory allocation for ClamAV from 2 to 4 GB