### PR TITLE
Deploy memory increase to dev environments

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: clamav-api-((project))
   instances: 1
-  memory: 2G
+  memory: 4G
   disk_quota: 2G
   docker:
     image: ajilaag/clamav-rest:20211026


### PR DESCRIPTION
Increase clamav memory from 2 to 4GB in the dev environments as a test before moving the the prod clamav app