### PR TITLE
Reduce the memory for the dev environments

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: clamav-api-((project))
   instances: 1
-  memory: 4G
+  memory: 2G
   disk_quota: 2G
   docker:
     image: ajilaag/clamav-rest:20211026


### PR DESCRIPTION
We've hit a limit on memory for ClamAV. We should reduce the memory allocated to the non-prod environments so that Prod gets the memory boost.

![Screenshot 2024-07-22 at 1 51 38 PM](https://github.com/user-attachments/assets/39048386-8c74-4028-b16b-9aaadf37d944)
