### PR TITLE
Update docker image tag for clamav-rest to 2025 version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   clamav-server:
-    image: ajilaag/clamav-rest:20221117
+    image: ajilaag/clamav-rest:20251115
     ports:
       - "9443:9443"
     environment:

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ applications:
   memory: 4G
   disk_quota: 2G
   docker:
-    image: ajilaag/clamav-rest:20211026
+    image: ajilaag/clamav-rest:20251115
   routes:
   - route: clamapi-((project)).apps.internal
   env:


### PR DESCRIPTION
Approving this PR will deploy it to dev, where we can verify the upload, merge it to dev, and then deploy to main