### PR TITLE
Health check and other reliability fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,14 @@ commands:
     description: "Login to cloud foundry space with service account credentials
       and push application using deployment configuration file."
     parameters:
+      cg_org:
+        description: "Cloud Foundry cloud.gov organization name"
+        default: "hhs-acf-ohs-tta"
+        type: string
+      cg_api:
+        description: "URL of Cloud Controller in Cloud Foundry cloud.gov instance"
+        default: "https://api.fr.cloud.gov"
+        type: string
       cloudgov_username:
         description: "Name of CircleCi project environment variable that
           holds deployer username for cloudgov space"
@@ -71,20 +79,12 @@ commands:
           command: cf push --var project=<< parameters.project >>
 
 parameters:
-  cg_org:
-    description: "Cloud Foundry cloud.gov organization name"
-    default: "hhs-acf-ohs-tta"
-    type: string
-  cg_api:
-    description: "URL of Cloud Controller in Cloud Foundry cloud.gov instance"
-    default: "https://api.fr.cloud.gov"
+  dev_git_branch:
+    description: "Github branch that will deploy to dev"
+    default: "ohs-deploy-dev"
     type: string
   prod_git_branch:
-    description: "Name of github branch that will deploy to prod"
+    description: "Github branch that will deploy to prod"
     default: "ohs-deploy-prod"
-    type: string
-  dev_git_branch:
-    description: "Name of github branch that will deploy to dev"
-    default: "ohs-deploy-dev"
     type: string
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
               -o << parameters.cg_org >> \
               -s ${<< parameters.cloudgov_space >>}
       - run:
-          name: Push application with deployment vars
+          name: Deploy to <<parameters.project>> from << pipeline.git.branch >>
           command: cf push --var project=<< parameters.project >>
       - run:
           name: Get logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,10 @@ version: 2.1
 
 workflows:
   deploy:
+    when: 
+      or:
+        - equal: [<< pipeline.git.branch >>, << pipeline.parameters.dev_git_branch >>]
+        - equal: [<< pipeline.git.branch >>, << pipeline.parameters.prod_git_branch >>]
     jobs:
       - deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,10 +69,10 @@ commands:
       - run:
           name: Login with service account
           command: |
-            cf login -a << pipeline.parameters.cg_api >> \
+            cf login -a << parameters.cg_api >> \
               -u ${<< parameters.cloudgov_username >>} \
               -p ${<< parameters.cloudgov_password >>} \
-              -o << pipeline.parameters.cg_org >> \
+              -o << parameters.cg_org >> \
               -s ${<< parameters.cloudgov_space >>}
       - run:
           name: Push application with deployment vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,41 @@
 version: 2.1
-orbs:
-  ruby: circleci/ruby@0.1.2
+
+workflows:
+  deploy:
+    jobs:
+      - deploy
+
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run:
+          name: Install cloud foundry
+          command: |
+            wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo gpg --dearmor -o /usr/share/keyrings/cli.cloudfoundry.org.gpg
+            echo "deb [signed-by=/usr/share/keyrings/cli.cloudfoundry.org.gpg] https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+            sudo apt-get update
+            sudo apt-get install cf8-cli
+      - when: # dev
+          condition:
+            equal: [<< pipeline.git.branch >>, << pipeline.parameters.dev_git_branch >>]
+          steps:
+            - cf_deploy:
+                cloudgov_username: CLOUDGOV_DEV_USERNAME
+                cloudgov_password: CLOUDGOV_DEV_PASSWORD
+                cloudgov_space: CLOUDGOV_DEV_SPACE
+                project: ttahub-dev
+      - when: # prod
+          condition:
+            equal: [<< pipeline.git.branch >>, << pipeline.parameters.prod_git_branch >>]
+          steps:
+            - cf_deploy:
+                cloudgov_username: CLOUDGOV_PROD_USERNAME
+                cloudgov_password: CLOUDGOV_PROD_PASSWORD
+                cloudgov_space: CLOUDGOV_PROD_SPACE
+                project: ttahub-prod
 
 commands:
   cf_deploy:
@@ -52,38 +87,4 @@ parameters:
     description: "Name of github branch that will deploy to dev"
     default: "ohs-deploy-dev"
     type: string
-jobs:
-  deploy:
-    docker:
-      - image: circleci/ruby:2.7.2
-    executor: ruby/default
-    steps:
-      - checkout
-      - run:
-          name: Install cloud foundry
-          command: |
-            curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
-            sudo dpkg -i cf-cli_amd64.deb
-      - when: # dev
-          condition:
-            equal: [<< pipeline.git.branch >>, << pipeline.parameters.dev_git_branch >>]
-          steps:
-            - cf_deploy:
-                cloudgov_username: CLOUDGOV_DEV_USERNAME
-                cloudgov_password: CLOUDGOV_DEV_PASSWORD
-                cloudgov_space: CLOUDGOV_DEV_SPACE
-                project: ttahub-dev
-      - when: # prod
-          condition:
-            equal: [<< pipeline.git.branch >>, << pipeline.parameters.prod_git_branch >>]
-          steps:
-            - cf_deploy:
-                cloudgov_username: CLOUDGOV_PROD_USERNAME
-                cloudgov_password: CLOUDGOV_PROD_PASSWORD
-                cloudgov_space: CLOUDGOV_PROD_SPACE
-                project: ttahub-prod
 
-workflows:
-  deploy:
-    jobs:
-      - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
                 cloudgov_password: CLOUDGOV_PROD_PASSWORD
                 cloudgov_space: CLOUDGOV_PROD_SPACE
                 project: ttahub-prod
+            
 
 commands:
   cf_deploy:
@@ -77,6 +78,11 @@ commands:
       - run:
           name: Push application with deployment vars
           command: cf push --var project=<< parameters.project >>
+      - run:
+          name: Get logs
+          when: always
+          command: cf logs clamav-api-<< parameters.project >> --recent
+      
 
 parameters:
   dev_git_branch:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Branches of this repository:
 
 Any custom work around deployment should branch off of `dev` before being merged and deployed.
 CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app)
+Push branch to remote, then trigger deploy job targeting dev with your branch.
 
 ## Why this project
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Branches of this repository:
 Any custom work around deployment should branch off of `dev` before being merged and deployed.
 CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app)
 Push branch to remote, then trigger deploy job targeting dev with your branch.
+Merge changes into `dev`, then `ohs-deploy-dev`, then `ohs-deploy-prod`
 
 ## Why this project
 
@@ -21,7 +22,7 @@ It is inspired by, and borrowed heavily from, https://blog.theodo.com/2017/11/im
 
 This manifest now runs a docker image from https://github.com/ajilaag/clamav-rest
 
-## Setup
+## Initial Setup
 
 This project depends on one deployment variable, which is documented in `vars.yml-template`
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Branches of this repository:
 * `ohs-deploy-prod` - Branch that gets auto-deployed to the `ttahub-prod` cloud.gov space
 
 Any custom work around deployment should branch off of `dev` before being merged and deployed.
+CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app)
 
 ## Why this project
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,22 @@ CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github
 Push branch to remote, then trigger deploy job targeting dev with your branch.
 Merge changes into `dev`, then `ohs-deploy-dev`, then `ohs-deploy-prod`
 
-## Why this project
+## Description
 
 This project aims to create a deployable cloud.gov app that will expose a REST api for scanning files for malware with ClamAV.
 
+This manifest runs a docker image from https://hub.docker.com/r/ajilaag/clamav-rest
+From the project maintained here: https://github.com/ajilaag/clamav-rest
 It is inspired by, and borrowed heavily from, https://blog.theodo.com/2017/11/implement-antivirus-api-10-min/
 
-This manifest now runs a docker image from https://github.com/ajilaag/clamav-rest
+The docker container runs an underlying freshclam service and REST API server.
+ClamAV file definitions will be automatically updated from an upstream server.
+
+## Troubleshooting
+
+*Error code 403 from the ClamAV Content Delivery Network (CDN)*
+This is likely due to running an out-of-date version of the freshclam service.
+Rebuild on the latest docker image and try redeploying the application.
 
 ## Initial Setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clamav-server:
-    image: ajilaag/clamav-rest:0.1.3
+    image: ajilaag/clamav-rest:latest
     ports:
       - "9443:9443"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,13 @@
-version: "3.5"
-
 services:
   clamav-server:
-    image: ajilaag/clamav-rest:20221117
+    image: ajilaag/clamav-rest:0.1.3
     ports:
       - "9443:9443"
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider https://localhost:9443/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
     environment:
       - MAX_FILE_SIZE=30M

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ applications:
   memory: 4G
   disk_quota: 2G
   docker:
-    image: ajilaag/clamav-rest:latest
+    image: ajilaag/clamav-rest:0.1.3
   routes:
   - route: clamapi-((project)).apps.internal
   health-check-type: http

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,5 +8,10 @@ applications:
     image: ajilaag/clamav-rest:20211026
   routes:
   - route: clamapi-((project)).apps.internal
+  health-check-type: http
+  health-check-http-endpoint: /
+  health-check-invocation-timeout: 5
+  health-check-interval: 60
+  timeout: 120
   env:
     MAX_FILE_SIZE: 30M

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ applications:
   memory: 4G
   disk_quota: 2G
   docker:
-    image: ajilaag/clamav-rest:20211026
+    image: ajilaag/clamav-rest:latest
   routes:
   - route: clamapi-((project)).apps.internal
   health-check-type: http


### PR DESCRIPTION
## Description
* Added HTTP health check in manifest to ensure the application is up and serving traffic.  If the health check fails, app will be automatically restarted.
* Reworked the CircleCI configuration.  Now uses cimg/base docker image, latest version of cf-cli tools, minimal required parameters, includes the target deploy and branch in pipeline, and gets the latest logs after cf push completes (useful in debugging failed deploy). 
* Misc doc updates
* Use `latest` tag version of the upstream Docker image.  This was due to observing following message in logs on failed startup, indicating that an out-of-date base clam version can result in rejection from the definition server.
> 2025-12-11T03:18:57.78-0800 [APP/PROC/WEB/0] ERR WARNING: FreshClam received error code 403 from the ClamAV Content Delivery Network (CDN).
2025-12-11T03:18:57.78-0800 [APP/PROC/WEB/0] OUT This could mean several things:
2025-12-11T03:18:57.78-0800 [APP/PROC/WEB/0] OUT 1. You are running an out-of-date version of ClamAV / FreshClam.
2025-12-11T03:18:57.78-0800 [APP/PROC/WEB/0] OUT Ensure you are the most updated version by visiting https://www.clamav.net/downloads

## Testing
* Validated the app comes up successfully and responds to requests in dev environment.
* Validated docker-compose up runs successfully on local
<img width="649" height="263" alt="Screenshot 2025-12-11 at 3 37 12 AM" src="https://github.com/user-attachments/assets/ff911693-806a-48e1-96ca-c2a034b84c0e" />
<img width="497" height="200" alt="Screenshot 2025-12-11 at 3 55 54 AM" src="https://github.com/user-attachments/assets/15d89a30-e236-4470-87cf-fc7b2191fd6f" />
<img width="1130" height="351" alt="Screenshot 2025-12-11 at 4 03 24 AM" src="https://github.com/user-attachments/assets/38f50672-806c-4c0c-afaf-22802a9808ed" />
