### PR TITLE
[TTAHUB-4663] fixup CircleCI config and readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
                 cloudgov_username: CLOUDGOV_PROD_USERNAME
                 cloudgov_password: CLOUDGOV_PROD_PASSWORD
                 cloudgov_space: CLOUDGOV_PROD_SPACE
-                deploy_config_file: deployment_config/prd_vars.yml
+                deploy_config_file: deployment_config/prod_vars.yml
                 project: ttahub-prod
             
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,19 @@ version: 2.1
 
 workflows:
   deploy:
-    when: 
-      or:
-        - equal: [<< pipeline.git.branch >>, << pipeline.parameters.dev_git_branch >>]
-        - equal: [<< pipeline.git.branch >>, << pipeline.parameters.prod_git_branch >>]
     jobs:
       - deploy
+
+parameters:
+  dev_git_branch:
+    description: "Github branch that will deploy to dev"
+    default: "ohs-deploy-dev"
+    type: string
+  prod_git_branch:
+    description: "Github branch that will deploy to prod"
+    default: "ohs-deploy-prod"
+    type: string
+
 
 jobs:
   deploy:
@@ -30,6 +37,7 @@ jobs:
                 cloudgov_username: CLOUDGOV_DEV_USERNAME
                 cloudgov_password: CLOUDGOV_DEV_PASSWORD
                 cloudgov_space: CLOUDGOV_DEV_SPACE
+                deploy_config_file: deployment_config/dev_vars.yml
                 project: ttahub-dev
       - when: # prod
           condition:
@@ -39,6 +47,7 @@ jobs:
                 cloudgov_username: CLOUDGOV_PROD_USERNAME
                 cloudgov_password: CLOUDGOV_PROD_PASSWORD
                 cloudgov_space: CLOUDGOV_PROD_SPACE
+                deploy_config_file: deployment_config/prd_vars.yml
                 project: ttahub-prod
             
 
@@ -93,14 +102,3 @@ commands:
           when: always
           command: cf logs clamav-api-<< parameters.project >> --recent
       
-
-parameters:
-  dev_git_branch:
-    description: "Github branch that will deploy to dev"
-    default: "ohs-deploy-dev"
-    type: string
-  prod_git_branch:
-    description: "Github branch that will deploy to prod"
-    default: "ohs-deploy-prod"
-    type: string
-

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Branches of this repository:
 * `ohs-deploy-dev` - Branch that gets auto-deployed to the `ttahub-dev` cloud.gov space
 * `ohs-deploy-prod` - Branch that gets auto-deployed to the `ttahub-prod` cloud.gov space
 
-Any custom work around deployment should branch off of `dev` before being merged and deployed.
-
-CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app).  Push branch to remote, then trigger deploy job targeting dev with your branch.  Merge changes into `dev`, then `ohs-deploy-dev`, then `ohs-deploy-prod`
+Any custom work around deployment should branch off of `dev` before being merged and deployed.  After pushing branch to remote, trigger deploy job targeting dev with your branch.  Merge changes into `dev` after approval, merge `dev` into `ohs-deploy-dev`, then into `ohs-deploy-prod`.  CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app).
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -10,24 +10,19 @@ Branches of this repository:
 * `ohs-deploy-prod` - Branch that gets auto-deployed to the `ttahub-prod` cloud.gov space
 
 Any custom work around deployment should branch off of `dev` before being merged and deployed.
-CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app)
-Push branch to remote, then trigger deploy job targeting dev with your branch.
-Merge changes into `dev`, then `ohs-deploy-dev`, then `ohs-deploy-prod`
+
+CircleCI pipelines can be found [here](https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app).  Push branch to remote, then trigger deploy job targeting dev with your branch.  Merge changes into `dev`, then `ohs-deploy-dev`, then `ohs-deploy-prod`
 
 ## Description
 
-This project aims to create a deployable cloud.gov app that will expose a REST api for scanning files for malware with ClamAV.
+This project aims to create a deployable cloud.gov app that will expose a REST api for scanning files for malware with ClamAV.  The docker container runs an underlying freshclam service and REST API server.  ClamAV file definitions will be automatically updated from an upstream server.
 
-This manifest runs a docker image from https://hub.docker.com/r/ajilaag/clamav-rest
-From the project maintained here: https://github.com/ajilaag/clamav-rest
-It is inspired by, and borrowed heavily from, https://blog.theodo.com/2017/11/implement-antivirus-api-10-min/
-
-The docker container runs an underlying freshclam service and REST API server.
-ClamAV file definitions will be automatically updated from an upstream server.
+This manifest runs a docker image from [ajilaag/clamav-rest](https://hub.docker.com/r/ajilaag/clamav-rest)
 
 ## Troubleshooting
 
 *Error code 403 from the ClamAV Content Delivery Network (CDN)*
+
 This is likely due to running an out-of-date version of the freshclam service.
 Rebuild on the latest docker image and try redeploying the application.
 


### PR DESCRIPTION
I did not look closely enough at the conflicts coming in when this was merged into the dev branch and broke the CircleCI config.

* Include reference to env-specific deploy vars when calling deploy
* Revert to allow running deploy job from user-supplied branch (previous behavior).
* Fixup README.md formatting

Successful deploy:
https://app.circleci.com/pipelines/github/HHS/Head-Start-clamav-api-cg-app/65/workflows/3e4009bd-19ee-4c5f-8bb1-d734765cfd1e/jobs/62

README can be previewed here:
https://github.com/HHS/Head-Start-clamav-api-cg-app/blob/tm/bad-merge/README.md