### PR TITLE
[TTAHUB-4663] More memory for container, use version 0.2.1

### DIFF
--- a/deployment_config/dev_vars.yml
+++ b/deployment_config/dev_vars.yml
@@ -1,1 +1,1 @@
-memory: 2G
+memory: 4G

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ applications:
   memory: ((memory))
   disk_quota: 2G
   docker:
-    image: ajilaag/clamav-rest:0.1.3
+    image: ajilaag/clamav-rest:0.2.1
   routes:
   - route: clamapi-((project)).apps.internal
   health-check-type: http


### PR DESCRIPTION
This service was sometimes still not working correctly when I test on dev through the application.  Running locally, I notice that the service sometimes uses more than 2GB of memory, while the dev configuration limits it to 2GB.  Adjusted configuration to 4GB in dev, service seems to behave more reliably.  Also pulled in the latest docker image, released today, which appears to use a local tcp socket/port to communicate with the daemon. Deployed multiple times to validate.

With the lower memory limit, it will often sit on `Reading databases from /clamav/data` step and never successfully reload.

<img width="1099" height="253" alt="Screenshot 2025-12-15 at 9 30 47 AM" src="https://github.com/user-attachments/assets/ecba5425-7119-4535-a157-47bbce25d3f0" />

<img width="608" height="170" alt="Screenshot 2025-12-15 at 9 33 04 AM" src="https://github.com/user-attachments/assets/7544505e-6c24-4981-aea7-6d3c0e35e320" />


