### PR TITLE
[TTAHUB-5449] Add security vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Do not report security vulnerabilities through GitHub issues, pull requests,
+discussions, public comments, or unsecured email.
+
+To report a vulnerability involving this repository, use the private
+**Report a vulnerability** option on the repository's **Security** tab.
+
+You may also submit a report through the
+[HHS vulnerability disclosure portal](https://hhs.responsibledisclosure.com/).
+Reports may be submitted anonymously.
+
+Before conducting security research, review the
+[HHS Vulnerability Disclosure Policy](https://www.hhs.gov/vulnerability-disclosure-policy/index.html)
+to understand which systems and research activities are authorized.
+
+If you encounter credentials, access tokens, personally identifiable
+information, production data, or other sensitive information, stop testing and
+report the issue through one of the private channels above as soon as possible.


### PR DESCRIPTION
## Description of change

Adds a root-level `SECURITY.md` documenting how to responsibly report security vulnerabilities in this repository. It directs reporters away from public GitHub issues/PRs/discussions and unsecured email, and toward the private GitHub Security tab, the HHS vulnerability disclosure portal, and the HHS Vulnerability Disclosure Policy.

## How to test

No application code changed. Verify the file renders correctly on GitHub and that the linked URLs (GitHub Security tab reporting, HHS disclosure portal, HHS VDP) are correct and reachable.

## Issue(s)

https://jira.acf.gov/browse/TTAHUB-5449